### PR TITLE
Updates with_path to add rewrite rules for post types and taxonomies. #8

### DIFF
--- a/lib/Nicholas.php
+++ b/lib/Nicholas.php
@@ -349,6 +349,15 @@ class Nicholas extends Underpin {
 		$uri                    = trailingslashit( $path );
 		$_SERVER['REQUEST_URI'] = $uri;
 		$wp                     = new WP();
+
+		foreach ( get_post_types( [], 'objects' ) as $post_type ) {
+			$post_type->add_rewrite_rules();
+		}
+
+		foreach( get_taxonomies([],'objects') as $taxonomy ){
+			$taxonomy->add_rewrite_rules();
+		}
+
 		$wp->parse_request();
 		query_posts( $wp->query_vars );
 		$post = get_post( $wp_query->posts[0] );


### PR DESCRIPTION
This resolves issue #8, which caused taxonomy and custom post type pages to fail to be recognized when their URL runs against `Nicholas::with_path`