### PR TITLE
Makes the page info REST endpoint extend-able. #9

### DIFF
--- a/lib/rest-endpoints/Page_Data.php
+++ b/lib/rest-endpoints/Page_Data.php
@@ -17,7 +17,7 @@ class Page_Data extends Nicholas_Endpoint {
 	public $description = 'Fetches data about the specified page';
 	public $route       = '/page-info';
 
-	public function get_postdata() {
+	public function get_postdata( $url ) {
 		global $wp_query;
 
 		$post_type = get_post_type();
@@ -38,7 +38,7 @@ class Page_Data extends Nicholas_Endpoint {
 
 		$preload_route = [ 'path' => $path, 'args' => [ 'include' => implode( ',', $post_ids ) ] ];
 
-		$posts         = Nicholas::request( 'GET', $preload_route['path'], $preload_route['args'] );
+		$posts = Nicholas::request( 'GET', $preload_route['path'], $preload_route['args'] );
 
 		// Move on to the next one if this URL does not have posts
 		if ( ! is_wp_error( $posts ) ) {
@@ -49,7 +49,6 @@ class Page_Data extends Nicholas_Endpoint {
 		}
 
 		// Get things specific to this query.
-		// Array values ensure that this will be an array in the JSON response.
 		$body_class = array_values( get_body_class() );
 
 		if ( ! isset( $type ) ) {
@@ -78,8 +77,26 @@ class Page_Data extends Nicholas_Endpoint {
 		}
 
 		$pagination = Nicholas::get_buffer( 'the_posts_pagination' );
+		$result     = [
+			'post_type'     => $post_type,
+			'comments_open' => comments_open(),
+			'posts'         => $posts,
+			'body_class'    => $body_class,
+			'type'          => $type,
+			'pagination'    => $pagination,
+		];
 
-		return [ 'comments_open' => comments_open(), 'posts' => $posts, 'body_class' => $body_class, 'type' => $type, 'pagination' => $pagination ];
+		/**
+		 * Filters the page info inside Nicholas.
+		 *
+		 * @since 1.0.1
+		 *
+		 * @param                 $result  The processed result thus-far.
+		 * @param WP_REST_Request $request The submitted request
+		 */
+		$result = apply_filters( 'nicholas/rest_endpoints/page_info', $result, $url );
+
+		return $result;
 	}
 
 	public function endpoint( WP_REST_Request $request ) {


### PR DESCRIPTION
Resolves issue #9 

This introduces a new filter, "nicholas/rest_endpoints/page_info", which makes it possible to filter the page data for any given URL.