### PR TITLE
Release/1.0.1

### DIFF
--- a/lib/Nicholas.php
+++ b/lib/Nicholas.php
@@ -349,6 +349,15 @@ class Nicholas extends Underpin {
 		$uri                    = trailingslashit( $path );
 		$_SERVER['REQUEST_URI'] = $uri;
 		$wp                     = new WP();
+
+		foreach ( get_post_types( [], 'objects' ) as $post_type ) {
+			$post_type->add_rewrite_rules();
+		}
+
+		foreach( get_taxonomies([],'objects') as $taxonomy ){
+			$taxonomy->add_rewrite_rules();
+		}
+
 		$wp->parse_request();
 		query_posts( $wp->query_vars );
 		$post = get_post( $wp_query->posts[0] );

--- a/lib/rest-endpoints/Page_Data.php
+++ b/lib/rest-endpoints/Page_Data.php
@@ -17,7 +17,7 @@ class Page_Data extends Nicholas_Endpoint {
 	public $description = 'Fetches data about the specified page';
 	public $route       = '/page-info';
 
-	public function get_postdata() {
+	public function get_postdata( $url ) {
 		global $wp_query;
 
 		$post_type = get_post_type();
@@ -38,7 +38,7 @@ class Page_Data extends Nicholas_Endpoint {
 
 		$preload_route = [ 'path' => $path, 'args' => [ 'include' => implode( ',', $post_ids ) ] ];
 
-		$posts         = Nicholas::request( 'GET', $preload_route['path'], $preload_route['args'] );
+		$posts = Nicholas::request( 'GET', $preload_route['path'], $preload_route['args'] );
 
 		// Move on to the next one if this URL does not have posts
 		if ( ! is_wp_error( $posts ) ) {
@@ -49,7 +49,6 @@ class Page_Data extends Nicholas_Endpoint {
 		}
 
 		// Get things specific to this query.
-		// Array values ensure that this will be an array in the JSON response.
 		$body_class = array_values( get_body_class() );
 
 		if ( ! isset( $type ) ) {
@@ -78,8 +77,26 @@ class Page_Data extends Nicholas_Endpoint {
 		}
 
 		$pagination = Nicholas::get_buffer( 'the_posts_pagination' );
+		$result     = [
+			'post_type'     => $post_type,
+			'comments_open' => comments_open(),
+			'posts'         => $posts,
+			'body_class'    => $body_class,
+			'type'          => $type,
+			'pagination'    => $pagination,
+		];
 
-		return [ 'comments_open' => comments_open(), 'posts' => $posts, 'body_class' => $body_class, 'type' => $type, 'pagination' => $pagination ];
+		/**
+		 * Filters the page info inside Nicholas.
+		 *
+		 * @since 1.0.1
+		 *
+		 * @param                 $result  The processed result thus-far.
+		 * @param WP_REST_Request $request The submitted request
+		 */
+		$result = apply_filters( 'nicholas/rest_endpoints/page_info', $result, $url );
+
+		return $result;
 	}
 
 	public function endpoint( WP_REST_Request $request ) {

--- a/lib/rest-endpoints/Page_Data.php
+++ b/lib/rest-endpoints/Page_Data.php
@@ -49,7 +49,8 @@ class Page_Data extends Nicholas_Endpoint {
 		}
 
 		// Get things specific to this query.
-		$body_class = get_body_class();
+		// Array values ensure that this will be an array in the JSON response.
+		$body_class = array_values( get_body_class() );
 
 		if ( ! isset( $type ) ) {
 			switch ( true ) {

--- a/lib/scripts/Editor.php
+++ b/lib/scripts/Editor.php
@@ -27,7 +27,8 @@ class Editor extends Script {
 	}
 
 	public function enqueue() {
-		if ( get_current_screen()->is_block_editor() ) {
+		// Only load this on block editor pages that have a CPT.
+		if ( get_current_screen()->is_block_editor() && get_post_type() ) {
 			parent::enqueue();
 		}
 	}


### PR DESCRIPTION
| Issue | Description | PR |
|----|----------------|------|
| #2 | in the page info endpoint, Body Class sometimes returns object instead of array | #3 |
| #8 | Custom Post Type & Custom taxonomy pages do not load via rest endpoint | #10 |
| #9  | Make page info extend-able | #11 |