### PR TITLE
Issue/6 - Makes use_compatibility_mode extend-able 

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,15 @@ This module is used in [a theme boilerplate](https://github.com/nicholas-wordpre
 
 ## Extending
 
-This is an [Underpin](github.com/underpin-WP/underpin) module, and the entrypoint for it is using the function `nicholas`, and it comes built-in with a handful of loaders:
+This is an [Underpin](github.com/underpin-WP/underpin) module, and the entrypoint for it is using the function
+`nicholas`, and it comes built-in with a handful of loaders:
 
 1. Script loader
-1. Rest Endpoint Loader
-1. Meta Loader
-1. Option Loader
-1. Template Loader
+2. Rest Endpoint Loader
+3. Meta Loader
+4. Option Loader
+5. Template Loader
+6. Decision List Loader
 
 ## Scripts
 
@@ -30,4 +32,5 @@ This module assumes that your theme has 3 scripts built-into the `build` directo
 
 ## REST Endpoints
 
-This module loads in a set of endpoints in the `nicholas/v1` namespace. These endpoints are used by the various scripts mentioned above to run the nearly-headless paradigm.
+This module loads in a set of endpoints in the `nicholas/v1` namespace. These endpoints are used by the various scripts
+mentioned above to run the nearly-headless paradigm.

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
     "require": {
         "underpin/underpin": "^1.3",
         "underpin/script-loader": "^1.1",
+        "underpin/decision-list-loader": "^1.0",
         "underpin/rest-endpoint-loader": "^1.0",
         "underpin/meta-loader": "^1.0",
         "underpin/option-loader": "^1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,548 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "91555808904175fc61e375275df7f937",
+    "packages": [
+        {
+            "name": "composer/installers",
+            "version": "v1.11.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/installers.git",
+                "reference": "ae03311f45dfe194412081526be2e003960df74b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/installers/zipball/ae03311f45dfe194412081526be2e003960df74b",
+                "reference": "ae03311f45dfe194412081526be2e003960df74b",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0 || ^2.0"
+            },
+            "replace": {
+                "roundcube/plugin-installer": "*",
+                "shama/baton": "*"
+            },
+            "require-dev": {
+                "composer/composer": "1.6.* || ^2.0",
+                "composer/semver": "^1 || ^3",
+                "phpstan/phpstan": "^0.12.55",
+                "phpstan/phpstan-phpunit": "^0.12.16",
+                "symfony/phpunit-bridge": "^4.2 || ^5",
+                "symfony/process": "^2.3"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Composer\\Installers\\Plugin",
+                "branch-alias": {
+                    "dev-main": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\Installers\\": "src/Composer/Installers"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Kyle Robinson Young",
+                    "email": "kyle@dontkry.com",
+                    "homepage": "https://github.com/shama"
+                }
+            ],
+            "description": "A multi-framework Composer library installer",
+            "homepage": "https://composer.github.io/installers/",
+            "keywords": [
+                "Craft",
+                "Dolibarr",
+                "Eliasis",
+                "Hurad",
+                "ImageCMS",
+                "Kanboard",
+                "Lan Management System",
+                "MODX Evo",
+                "MantisBT",
+                "Mautic",
+                "Maya",
+                "OXID",
+                "Plentymarkets",
+                "Porto",
+                "RadPHP",
+                "SMF",
+                "Starbug",
+                "Thelia",
+                "Whmcs",
+                "WolfCMS",
+                "agl",
+                "aimeos",
+                "annotatecms",
+                "attogram",
+                "bitrix",
+                "cakephp",
+                "chef",
+                "cockpit",
+                "codeigniter",
+                "concrete5",
+                "croogo",
+                "dokuwiki",
+                "drupal",
+                "eZ Platform",
+                "elgg",
+                "expressionengine",
+                "fuelphp",
+                "grav",
+                "installer",
+                "itop",
+                "joomla",
+                "known",
+                "kohana",
+                "laravel",
+                "lavalite",
+                "lithium",
+                "magento",
+                "majima",
+                "mako",
+                "mediawiki",
+                "miaoxing",
+                "modulework",
+                "modx",
+                "moodle",
+                "osclass",
+                "phpbb",
+                "piwik",
+                "ppi",
+                "processwire",
+                "puppet",
+                "pxcms",
+                "reindex",
+                "roundcube",
+                "shopware",
+                "silverstripe",
+                "sydes",
+                "sylius",
+                "symfony",
+                "tastyigniter",
+                "typo3",
+                "wordpress",
+                "yawik",
+                "zend",
+                "zikula"
+            ],
+            "support": {
+                "issues": "https://github.com/composer/installers/issues",
+                "source": "https://github.com/composer/installers/tree/v1.11.0"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-04-28T06:42:17+00:00"
+        },
+        {
+            "name": "underpin/cron-job-loader",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Underpin-WP/cron-job-loader.git",
+                "reference": "2676e465f934e883d8fba7707e3c2b34d7413066"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Underpin-WP/cron-job-loader/zipball/2676e465f934e883d8fba7707e3c2b34d7413066",
+                "reference": "2676e465f934e883d8fba7707e3c2b34d7413066",
+                "shasum": ""
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "cron-jobs.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Alex Standiford",
+                    "email": "a@alexstandiford.com"
+                }
+            ],
+            "description": "Cron Job Loader for Underpin",
+            "support": {
+                "issues": "https://github.com/Underpin-WP/cron-job-loader/issues",
+                "source": "https://github.com/Underpin-WP/cron-job-loader/tree/1.0.0"
+            },
+            "time": "2021-05-11T18:35:25+00:00"
+        },
+        {
+            "name": "underpin/decision-list-loader",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Underpin-WP/decision-list-loader.git",
+                "reference": "1b17e130157e7aba4dad36e0b68f8b0f3aee0323"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Underpin-WP/decision-list-loader/zipball/1b17e130157e7aba4dad36e0b68f8b0f3aee0323",
+                "reference": "1b17e130157e7aba4dad36e0b68f8b0f3aee0323",
+                "shasum": ""
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "decision-lists.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Alex Standiford",
+                    "email": "a@alexstandiford.com"
+                }
+            ],
+            "description": "Decision List loader for Underpin",
+            "support": {
+                "issues": "https://github.com/Underpin-WP/decision-list-loader/issues",
+                "source": "https://github.com/Underpin-WP/decision-list-loader/tree/1.0.0"
+            },
+            "time": "2021-05-06T00:44:13+00:00"
+        },
+        {
+            "name": "underpin/logger-loader",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Underpin-WP/logger-loader.git",
+                "reference": "713ff0ab28ac55562facc897eddc22f66536c119"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Underpin-WP/logger-loader/zipball/713ff0ab28ac55562facc897eddc22f66536c119",
+                "reference": "713ff0ab28ac55562facc897eddc22f66536c119",
+                "shasum": ""
+            },
+            "require": {
+                "underpin/cron-job-loader": "^1.0",
+                "underpin/decision-list-loader": "^1.0"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "logger.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Alex Standiford",
+                    "email": "a@alexstandiford.com"
+                }
+            ],
+            "description": "Logger Loader for Underpin",
+            "support": {
+                "issues": "https://github.com/Underpin-WP/logger-loader/issues",
+                "source": "https://github.com/Underpin-WP/logger-loader/tree/2.0.0"
+            },
+            "time": "2021-08-05T13:06:26+00:00"
+        },
+        {
+            "name": "underpin/meta-loader",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Underpin-WP/meta-loader.git",
+                "reference": "2222ff25decf594ef912ac1d0790d1ba67813061"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Underpin-WP/meta-loader/zipball/2222ff25decf594ef912ac1d0790d1ba67813061",
+                "reference": "2222ff25decf594ef912ac1d0790d1ba67813061",
+                "shasum": ""
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "meta.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Alex Standiford",
+                    "email": "a@alexstandiford.com"
+                }
+            ],
+            "description": "Meta loader for Underpin",
+            "support": {
+                "issues": "https://github.com/Underpin-WP/meta-loader/issues",
+                "source": "https://github.com/Underpin-WP/meta-loader/tree/1.0.0"
+            },
+            "time": "2021-05-09T14:00:43+00:00"
+        },
+        {
+            "name": "underpin/option-loader",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Underpin-WP/option-loader.git",
+                "reference": "b9e66e11264162827ff7dce3c0a8992932497304"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Underpin-WP/option-loader/zipball/b9e66e11264162827ff7dce3c0a8992932497304",
+                "reference": "b9e66e11264162827ff7dce3c0a8992932497304",
+                "shasum": ""
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "options.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Alex Standiford",
+                    "email": "a@alexstandiford.com"
+                }
+            ],
+            "description": "Option loader for Underpin",
+            "support": {
+                "issues": "https://github.com/Underpin-WP/option-loader/issues",
+                "source": "https://github.com/Underpin-WP/option-loader/tree/1.0.1"
+            },
+            "time": "2021-08-25T23:24:29+00:00"
+        },
+        {
+            "name": "underpin/rest-endpoint-loader",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Underpin-WP/rest-endpoint-loader.git",
+                "reference": "01fb7e7b2260e5b5a9918d7120c78f614ce43b38"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Underpin-WP/rest-endpoint-loader/zipball/01fb7e7b2260e5b5a9918d7120c78f614ce43b38",
+                "reference": "01fb7e7b2260e5b5a9918d7120c78f614ce43b38",
+                "shasum": ""
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "rest-endpoints.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Alex Standiford",
+                    "email": "a@alexstandiford.com"
+                }
+            ],
+            "description": "Rest endpoint loader for Underpin",
+            "support": {
+                "issues": "https://github.com/Underpin-WP/rest-endpoint-loader/issues",
+                "source": "https://github.com/Underpin-WP/rest-endpoint-loader/tree/1.0.0"
+            },
+            "time": "2021-05-06T00:45:07+00:00"
+        },
+        {
+            "name": "underpin/script-loader",
+            "version": "1.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Underpin-WP/script-loader.git",
+                "reference": "4816f95ca7c4351803e720b83d7e4aefa21cf1e4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Underpin-WP/script-loader/zipball/4816f95ca7c4351803e720b83d7e4aefa21cf1e4",
+                "reference": "4816f95ca7c4351803e720b83d7e4aefa21cf1e4",
+                "shasum": ""
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "scripts.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Alex Standiford",
+                    "email": "a@alexstandiford.com"
+                }
+            ],
+            "description": "Script Loader for Underpin",
+            "support": {
+                "issues": "https://github.com/Underpin-WP/script-loader/issues",
+                "source": "https://github.com/Underpin-WP/script-loader/tree/1.1.3"
+            },
+            "time": "2021-08-25T23:19:49+00:00"
+        },
+        {
+            "name": "underpin/template-loader",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Underpin-WP/template-loader.git",
+                "reference": "76df5f4b0139257ffe944603760f9b5493bf82bd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Underpin-WP/template-loader/zipball/76df5f4b0139257ffe944603760f9b5493bf82bd",
+                "reference": "76df5f4b0139257ffe944603760f9b5493bf82bd",
+                "shasum": ""
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "templates.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Alex Standiford",
+                    "email": "a@alexstandiford.com"
+                }
+            ],
+            "description": "Template loader for Underpin. Intended to be used by WordPress themes.",
+            "support": {
+                "issues": "https://github.com/Underpin-WP/template-loader/issues",
+                "source": "https://github.com/Underpin-WP/template-loader/tree/1.0.0"
+            },
+            "time": "2021-08-14T18:36:46+00:00"
+        },
+        {
+            "name": "underpin/underpin",
+            "version": "1.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Underpin-WP/underpin.git",
+                "reference": "926cb0a236ce630766318794a42f4de9568724f9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Underpin-WP/underpin/zipball/926cb0a236ce630766318794a42f4de9568724f9",
+                "reference": "926cb0a236ce630766318794a42f4de9568724f9",
+                "shasum": ""
+            },
+            "require": {
+                "composer/installers": "^1.10",
+                "underpin/logger-loader": "^2.0"
+            },
+            "type": "wordpress-muplugin",
+            "autoload": {
+                "files": [
+                    "Underpin.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Alex Standiford",
+                    "email": "a@alexstandiford.com"
+                }
+            ],
+            "description": "Underpin WordPress framework",
+            "support": {
+                "issues": "https://github.com/Underpin-WP/underpin/issues",
+                "source": "https://github.com/Underpin-WP/underpin/tree/1.3.1"
+            },
+            "time": "2021-08-05T13:06:29+00:00"
+        }
+    ],
+    "packages-dev": [
+        {
+            "name": "underpin/debug-bar-extension",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Underpin-WP/debug-bar-extension.git",
+                "reference": "6a025f763a7a457449bba511ed3651bdfbaa9366"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Underpin-WP/debug-bar-extension/zipball/6a025f763a7a457449bba511ed3651bdfbaa9366",
+                "reference": "6a025f763a7a457449bba511ed3651bdfbaa9366",
+                "shasum": ""
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "debug-bar.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Alex Standiford",
+                    "email": "a@alexstandiford.com"
+                }
+            ],
+            "description": "Extension to integrate Debug Bar in Underpin",
+            "support": {
+                "issues": "https://github.com/Underpin-WP/debug-bar-extension/issues",
+                "source": "https://github.com/Underpin-WP/debug-bar-extension/tree/1.0.0"
+            },
+            "time": "2021-05-12T04:17:04+00:00"
+        }
+    ],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": [],
+    "plugin-api-version": "2.0.0"
+}


### PR DESCRIPTION
Issue #6 

This updates `Nicholas::use_compatibility_mode()` to be extend-able using an Underpin [decision list](https://github.com/Underpin-WP/decision-list-loader) called `use_compatibility_mode`.

To extend the decision list, you can do something like this:

```php
nicholas()->decision_lists()->get( 'use_compatibility_mode' )->add( 'always_use_compatibility_mode', [
	'name'                   => 'Always Use Compatibility Mode', // Used for debugging purposes. Be kind, always add this.
	'description'            => 'Forces this theme to always use compatibility mode, entirely defeating the purpose of Nearly Headless', // Used for debugging purposes. Be kind, always add this.
	'valid_callback'         => '__return_true', // Return true to make this the decision to use. WP_Error otherwise.
	'valid_actions_callback' => '__return_true', // Return true if valid
	'priority'               => 1, // Low priority forces this to run before other checks.
] );
```

This specific decision would force _all_ pages to load in compatibility mode because `validate_callback` is `true`.