### PR TITLE
Issue/1 - Updates Nicholas to support a way to flush a session's cache.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,9 @@ This is an [Underpin](github.com/underpin-WP/underpin) module, and the entrypoin
 This module assumes that your theme has 3 scripts built-into the `build` directory of your theme:
 
 1. admin.js - Gets enqueued in the settings screen located in **Settings>>>Nicholas Settings**
-1. editor.js - Gets enqueued on block editor pages
-1. theme.js - Gets enqueued on front-end pages that are not using compatibility mode
+2. editor.js - Gets enqueued on block editor pages
+3. theme.js - Gets enqueued on front-end pages that are not using compatibility mode
+4. sessionManager.js - Forces a session to clear the cache if the `nicholas_flush_cache` cookie is set.
 
 ## REST Endpoints
 

--- a/lib/Nicholas.php
+++ b/lib/Nicholas.php
@@ -208,6 +208,17 @@ class Nicholas extends Underpin {
 	}
 
 	/**
+	 * Instructs the client to flush the cache on-load.
+	 *
+	 * @since 1.0.2
+	 */
+	public static function flush_session_cache() {
+		if ( ! isset( $_COOKIE["nicholas_flush_cache"] ) ) {
+			setcookie( 'nicholas_flush_cache', true );
+		}
+	}
+
+	/**
 	 * Returns true if this page should be loaded using compatibility mode.
 	 *
 	 * @since 1.0.0
@@ -379,6 +390,18 @@ class Nicholas extends Underpin {
 		$this->scripts()->add( 'theme', 'Nicholas\Scripts\Theme' );
 		$this->scripts()->add( 'editor', 'Nicholas\Scripts\Editor' );
 		$this->scripts()->add( 'admin', 'Nicholas\Scripts\Admin' );
+		$this->scripts()->add( 'session_manager', [
+			'handle'      => 'sessionManager',
+			'src'         => $this->asset_url() . 'sessionManager.js',
+			'deps'        => $this->asset_dir() . 'sessionManager.asset.php',
+			'name'        => 'Nicholas Session Manager',
+			'description' => 'Clears the current session data when the server instructs it to-do so.',
+			// Enqueue Session manager on admin and login screens
+			'middlewares' => [
+				'Underpin_Scripts\Factories\Enqueue_Admin_Script',
+				'Underpin_Scripts\Factories\Enqueue_Login_Script'
+			]
+		] );
 
 		/**
 		 * Register REST Endpoints
@@ -489,6 +512,10 @@ class Nicholas extends Underpin {
 				do_action( 'nicholas/enqueue_app_scripts' );
 			}
 		} );
+
+		// Force this session to clear the cache when a user logs in, or logs out.
+		add_action( 'wp_logout', [ $this, 'flush_session_cache' ] );
+		add_action( 'wp_login', [ $this, 'flush_session_cache' ] );
 	}
 
 


### PR DESCRIPTION
Resolves #1 

When `Nicholas::flush_session_cache()` is ran, a cookie is set in the session. This cookie is caught by the browser on-load, and signals the browser to flush the session storage of the current session.

This also sets up the session cache to be flushed when someone logs in, or logs out of WordPress.